### PR TITLE
feat: Add support for prebuilt Erlang/OTP on macOS

### DIFF
--- a/.github/workflows/e2e_test_darwin_prebuilt.yaml
+++ b/.github/workflows/e2e_test_darwin_prebuilt.yaml
@@ -1,0 +1,104 @@
+name: E2E tests on macOS (Prebuilt release)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *' # daily at midnight
+  workflow_dispatch:
+
+jobs:
+  e2e_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        arch: [x86_64, arm64]
+        erlang_version: [OTP-27.0.1] # Check assets/prebuilt_versions.txt for available versions
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build vfox (macOS)
+        shell: bash
+        run: |
+          git clone https://github.com/version-fox/vfox.git ../vfox-repo
+          cd ../vfox-repo
+          go build -ldflags="-s -w" -o ./vfox main.go
+          echo "Built vfox at $(pwd)/vfox"
+          echo "$(pwd)" >> $GITHUB_PATH
+          vfox --version
+          cd $GITHUB_WORKSPACE
+
+      - name: Add vfox-erlang plugin
+        shell: bash
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          echo "Attempting to add plugin from source: https://github.com/version-fox/vfox-erlang/archive/${GITHUB_REF}.zip"
+          vfox add --source "https://github.com/version-fox/vfox-erlang/archive/${GITHUB_REF}.zip" erlang
+          vfox info erlang
+
+      - name: Set Prebuilt Env for macOS
+        run: |
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            echo "USE_PREBUILT_OTP=aarch64-apple-darwin" >> $GITHUB_ENV
+            echo "Selected aarch64-apple-darwin for arm64"
+          else
+            echo "USE_PREBUILT_OTP=x86_64-apple-darwin" >> $GITHUB_ENV
+            echo "Selected x86_64-apple-darwin for x86_64"
+          fi
+        shell: bash
+
+      - name: Install Erlang/OTP
+        shell: bash
+        run: |
+          echo "USE_PREBUILT_OTP is: $USE_PREBUILT_OTP"
+          export MAKEFLAGS=-j4 # May not be needed for prebuilt, but harmless
+          echo "Installing Erlang/OTP ${{ matrix.erlang_version }}..."
+          vfox install erlang@${{ matrix.erlang_version }}
+          echo "Installation completed."
+          vfox use -g erlang@${{ matrix.erlang_version }}
+          echo "Set global version."
+          echo ">>>>> vfox version: $(vfox --version)"
+          echo ">>>>> current vfox erlang: $(vfox current erlang)"
+          eval "$(vfox activate bash)"
+          echo "vfox activated."
+
+      - name: Verify Installation
+        shell: bash
+        run: |
+          echo "PATH is: $PATH"
+          which erl
+          erl -version
+          echo "Navigating to assets directory: $GITHUB_WORKSPACE/assets"
+          cd "$GITHUB_WORKSPACE/assets"
+          ls -la
+          echo "Compiling hello.erl..."
+          erlc hello.erl
+          echo "Running hello_world..."
+          erl -noshell -s hello hello_world -s init stop
+          echo "Erlang test script executed successfully."
+          # Check if specific files exist from prebuilt package if needed
+          # Example: check for a common lib or include file
+          # ls -l $(dirname $(which erl))/../lib/
+          # ls -l $(dirname $(which erl))/../erts-*/include/
+          # if [ ! -d "$(dirname $(which erl))/../lib/asn1" ]; then
+          #   echo "Error: asn1 library not found"
+          #   exit 1
+          # fi
+          # if [ ! -f "$(dirname $(which erl))/../erts-$(erl -noshell -eval 'io:format("~s", [erlang:system_info(version)]).' -s init stop)/include/erl_nif.h" ]; then
+          #  echo "Error: erl_nif.h not found"
+          #  exit 1
+          # fi
+          echo "Prebuilt Erlang/OTP ${{ matrix.erlang_version }} on ${{ matrix.arch }} verified."

--- a/README.md
+++ b/README.md
@@ -83,17 +83,44 @@ Invoke-Expression "$(vfox activate pwsh)"
 
 You can reference the E2E test in in windows-2022: [.github/workflows/e2e_test_windows.yaml](.github/workflows/e2e_test_windows.yaml)
 
-## install a prebuilt Erlang/OTP version
+## Install a Prebuilt Erlang/OTP Version
 
-After vfox-erlang v1.1.0, you can also install a prebuilt Erlang/OTP version in Ubuntu linux system. 
+After vfox-erlang v1.1.0, you can install prebuilt Erlang/OTP versions, which can be significantly faster than compiling from source.
 
-**Before install, you must disable vfox search cache.** Reference: [https://vfox.lhan.me/guides/configuration.html#cache-settings](https://vfox.lhan.me/guides/configuration.html#cache-settings)
+**Before installing, you might need to disable the vfox search cache if you encounter issues finding prebuilt versions.** Reference: [https://vfox.lhan.me/guides/configuration.html#cache-settings](https://vfox.lhan.me/guides/configuration.html#cache-settings)
 
-This is an installation example in Bash Shell:
+To use a prebuilt binary, set the `USE_PREBUILT_OTP` environment variable before running `vfox install` or `vfox search`.
 
+### For Linux (Ubuntu)
+
+Prebuilt binaries for Ubuntu are sourced from `https://builds.hex.pm/builds/otp/`.
+
+Example:
 ```shell
-# install an available version, you can also a avaliable version in: https://bobs-list.kobrakai.de/
+# Search for available prebuilt versions for Ubuntu 20.04
 USE_PREBUILT_OTP="ubuntu-20.04" vfox search erlang
-```
 
-**USE_PREBUILT_OTP** var value is one of: ["ubuntu-14.04", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"].
+# Install a specific version
+USE_PREBUILT_OTP="ubuntu-20.04" vfox install erlang@26.2.2
+```
+Supported `USE_PREBUILT_OTP` values for Linux include: "ubuntu-14.04", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04". Ensure the Erlang version you wish to install is available for your chosen Ubuntu release at `https://builds.hex.pm/builds/otp/`.
+
+### For macOS (Darwin)
+
+Prebuilt binaries for macOS (x86_64 and Apple Silicon/aarch64) are sourced from `https://github.com/erlef/otp_builds`.
+
+Set `USE_PREBUILT_OTP` to your target architecture:
+- For Intel (x86_64): `export USE_PREBUILT_OTP="x86_64-apple-darwin"`
+- For Apple Silicon (aarch64): `export USE_PREBUILT_OTP="aarch64-apple-darwin"`
+
+Example:
+```shell
+# Install on Apple Silicon
+export USE_PREBUILT_OTP="aarch64-apple-darwin"
+vfox install erlang@OTP-27.0.1 
+
+# Install on Intel Mac
+export USE_PREBUILT_OTP="x86_64-apple-darwin"
+vfox install erlang@OTP-27.0.1
+```
+**Note:** Ensure the Erlang/OTP version (e.g., `OTP-27.0.1`) you specify with `vfox install erlang@<version>` is available as a prebuilt release at `https://github.com/erlef/otp_builds/releases`. The version format for these prebuilt binaries typically includes "OTP-", like `OTP-27.0.1`, which might differ from the source release tags (e.g., `27.0.1`). You can check the available tags on the `erlef/otp_builds` releases page.

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -30,6 +30,13 @@ function PLUGIN:PreInstall(ctx)
                 "Make sure the USE_PREBUILT environment variable is set to one of the following values: ubuntu-20.04, ubuntu-22.04, ubuntu-24.04")
         end
         download_url = "https://builds.hex.pm/builds/otp/" .. RUNTIME.archType .. "/" .. PRE_BUILT_OS_RELEASE .. "/" .. erlang_version .. ".tar.gz"
+    elseif RUNTIME.osType == "darwin" and PRE_BUILT_OS_RELEASE then
+        local SUPPORT_OS_RELEASE = { "x86_64-apple-darwin", "aarch64-apple-darwin" }
+        if not erlangUtils.array_contains(SUPPORT_OS_RELEASE, PRE_BUILT_OS_RELEASE) then
+            error(
+                "For macOS, USE_PREBUILT_OTP must be set to 'x86_64-apple-darwin' or 'aarch64-apple-darwin'")
+        end
+        download_url = "https://github.com/erlef/otp_builds/releases/download/" .. erlang_version .. "/otp-" .. PRE_BUILT_OS_RELEASE .. ".tar.gz"
     else
         download_url = "https://github.com/erlang/otp/archive/refs/tags/OTP-" .. erlang_version .. ".tar.gz"
     end


### PR DESCRIPTION
This change introduces support for installing prebuilt Erlang/OTP binaries on macOS (darwin) using the `erlef/otp_builds` releases.

Key changes:
- I modified `hooks/pre_install.lua` to detect macOS and construct download URLs for prebuilt binaries from `https://github.com/erlef/otp_builds` when `USE_PREBUILT_OTP` is set to a valid macOS target (`x86_64-apple-darwin` or `aarch64-apple-darwin`).
- I updated `README.md` to document how to use `USE_PREBUILT_OTP` for macOS, providing examples for both x86_64 and aarch64 architectures.
- I added a new GitHub Actions workflow (`.github/workflows/e2e_test_darwin_prebuilt.yaml`) to perform end-to-end testing of prebuilt Erlang/OTP installations on `macos-latest` for both x86_64 and arm64 architectures.

This allows macOS users to significantly speed up Erlang/OTP installation by using precompiled binaries instead of building from source.